### PR TITLE
Add default tooltip arrow style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Vuetify-Tooltip
-the given css adda an arrow to the vuetify tootltip
+the given css add an arrow to the vuetify tootltip
 
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ this how u can implement it
 </v-tooltip>
 ```
 
+and for Vuetify's default tooltip style:
+
+```html
+<v-tooltip content-class="tooltip-top"></v-tooltip>
+```
+
 ![image](https://user-images.githubusercontent.com/20104015/127085657-a5635a86-3b27-4689-b737-1b608d9ffd42.png)

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # Vuetify-Tooltip
+
 the given css add an arrow to the vuetify tootltip
 
-
 ## Contributions
+
 All contributions and suggestions are welcome
 
 ## Usage
 
 this how u can implement it
 
-
-                    <v-tooltip top content-class="primary tooltip-top">
-                            <template v-slot:activator="{ on, attrs }">
-                                <v-btn
-                                    v-bind="attrs"
-                                    v-on="on"
-                                    icon
-                                    color="primary"
-                                    @click="editItem(item)"
-                                >
-                                    <v-icon>mdi-pencil</v-icon>
-                                </v-btn>
-                            </template>
-                            <span>Edit Details</span>
-                        </v-tooltip>
-
+```html
+<v-tooltip top content-class="primary tooltip-top">
+  <template v-slot:activator="{ on, attrs }">
+    <v-btn
+      v-bind="attrs"
+      v-on="on"
+      icon
+      color="primary"
+      @click="editItem(item)"
+    >
+      <v-icon>mdi-pencil</v-icon>
+    </v-btn>
+  </template>
+  <span>Edit Details</span>
+</v-tooltip>
+```
 
 ![image](https://user-images.githubusercontent.com/20104015/127085657-a5635a86-3b27-4689-b737-1b608d9ffd42.png)

--- a/tooltip.css
+++ b/tooltip.css
@@ -6,7 +6,7 @@
     position: absolute;
     z-index: -21;
     content: '';
-    top: 100%;
+    top: 100%; /* To the top of the tooltip */
     left: 50%;
     height: 0;
     width: 0;
@@ -43,7 +43,7 @@
     position: absolute;
     z-index: -21;
     content: '';
-    bottom: 100%;
+    bottom: 100%; /* To the bottom of the tooltip */
     left: 50%;
     height: 0;
     width: 0;
@@ -77,7 +77,7 @@
     content: " ";
     position: absolute;
     top: 50%;
-    right: 100%; /* To the left of the tooltip */
+    right: 100%; /* To the right of the tooltip */
     margin-top: -8px;
     border-width: 8px;
     border-style: solid;

--- a/tooltip.css
+++ b/tooltip.css
@@ -11,6 +11,11 @@
     height: 0;
     width: 0;
 }
+
+.tooltip-top::before{
+    border-top: solid 8px rgba(0, 0, 0, 0.54) !important;
+}
+
 .tooltip-top.error::before{
     border-top: solid 8px #ff6060;
 }
@@ -42,6 +47,10 @@
     left: 50%;
     height: 0;
     width: 0;
+}
+
+.tooltip-bottom::before{
+    border-bottom: solid 8px rgba(0, 0, 0, 0.54) !important;
 }
 
 .tooltip-bottom.error::before{
@@ -77,6 +86,10 @@
     border-left: solid 8px transparent;
 }
 
+.tooltip-right::before{
+    border-right: solid 8px rgba(0, 0, 0, 0.54) !important;
+}
+
 .tooltip-right.error::before{
     border-right: solid 8px #ff6060 !important;
 }
@@ -109,6 +122,10 @@
     border-top: solid 8px transparent;
     border-bottom: solid 8px transparent;
     border-right: solid 8px transparent;
+}
+
+.tooltip-left::before{
+    border-left: solid 8px rgba(0, 0, 0, 0.54) !important;
 }
 
 .tooltip-left.error::before{


### PR DESCRIPTION
Hi, thanks for this repo and it helps me a lot! 
I've add a default style to it (same as Vuetify's default tooltip color):

Example:

<img width="148" alt="Screen Shot 2022-05-27 at 9 40 45 AM" src="https://user-images.githubusercontent.com/12791264/170611566-c14b8c87-6814-410c-94e5-7be0cc0915e4.png">

User can just use something like `content-class="tooltip-left"` without adding color to it.

Best,
DriftKingTW